### PR TITLE
Don't display impossible numbers.

### DIFF
--- a/src/components/hint.tsx
+++ b/src/components/hint.tsx
@@ -35,7 +35,6 @@ export default function Hint(props: Props) {
 
       {hint === IHintLevel.IMPOSSIBLE && (
         <div className="w-100 h-100 relative flex justify-center items-center">
-          {type === "number" && <Txt className="absolute white o-50" value={value} />}
           <div className={`absolute w-100 o-80 rotate-135 bg-${color} b--${color}`} style={{ height: "2px" }} />
         </div>
       )}


### PR DESCRIPTION
The grayed-out numbers were hard to read and unnecessary.